### PR TITLE
feat: support window titles with large number formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,10 @@ python scripts/build.py
 **Bot doesn't find the game?**
 - Make sure Cookie Clicker is running
 - Use windowed mode (not fullscreen)
-- Check the window title matches: "X cookies - Cookie Clicker"
+- Check the window title matches one of these patterns:
+  - `245 cookies - Cookie Clicker`
+  - `72.197 million cookies - Cookie Clicker`
+  - `13.564 billion cookies - Cookie Clicker`
 
 **Clicks in wrong position?**
 - Enable overlay to see where it clicks

--- a/src/window_finder.py
+++ b/src/window_finder.py
@@ -11,9 +11,14 @@ class CookieClickerWindowFinder:
     @staticmethod
     def is_cookie_clicker_window(title: str) -> bool:
         """Verify if the title matches the dynamic Cookie Clicker pattern."""
-        # Pattern: "[number with possible commas] cookies - Cookie Clicker"
-        # Examples: "245 cookies", "1,111 cookies", "19,631 cookies"
-        pattern = r"^[\d,]+\s*cookies\s*-\s*Cookie Clicker$"
+        # Pattern: "[number] [optional: million/billion/trillion/etc.] cookies - Cookie Clicker"
+        # Examples:
+        #   - "245 cookies - Cookie Clicker"
+        #   - "1,111 cookies - Cookie Clicker"
+        #   - "72.197 million cookies - Cookie Clicker"
+        #   - "13.564 billion cookies - Cookie Clicker"
+        #   - "6.432 trillion cookies - Cookie Clicker"
+        pattern = r"^[\d,\.]+\s*(million|billion|trillion|quadrillion|quintillion)?\s*cookies\s*-\s*Cookie Clicker$"
         return bool(re.match(pattern, title, re.IGNORECASE))
 
     def find_window(self) -> int | None:
@@ -29,7 +34,8 @@ class CookieClickerWindowFinder:
         win32gui.EnumWindows(enum_window_callback, windows)
 
         if not windows:
-            print("❌ No window found with pattern 'X cookies - Cookie Clicker'")
+            print("❌ No window found with pattern '[number] [unit] cookies - Cookie Clicker'")
+            print("   Examples: '245 cookies', '72.197 million cookies', '13.564 billion cookies'")
             self._print_diagnostic_info()
             return None
 


### PR DESCRIPTION
##  Summary

This PR adds support for Cookie Clicker window titles that use large number formats (million, billion, trillion, etc.).

##  Changes

### Window Detection Enhancement
-  Updated regex pattern to accept decimal numbers
-  Support for number units: million, billion, trillion, quadrillion, quintillion
-  Backward compatible with simple number formats

### Examples of Supported Formats

**Before (only these worked):**
- 245 cookies - Cookie Clicker
- 1,111 cookies - Cookie Clicker

**After (all of these work):**
- 245 cookies - Cookie Clicker 
- 1,111 cookies - Cookie Clicker 
- 72.197 million cookies - Cookie Clicker  NEW
- 13.564 billion cookies - Cookie Clicker  NEW
- 6.432 trillion cookies - Cookie Clicker  NEW

### Technical Details

**Updated Regex Pattern:**
\\\egex
^[\d,\.]+\s*(million|billion|trillion|quadrillion|quintillion)?\s*cookies\s*-\s*Cookie Clicker$
\\\

**Key Features:**
- Accepts decimals (.) and commas (,)
- Optional unit suffix (case-insensitive)
- Maintains backward compatibility

##  Documentation

-  Updated README.md with new examples
-  Updated error messages with clearer format examples
-  Added inline code comments explaining the pattern

##  Testing

Tested with various window title formats:
-  Small numbers: 245 cookies
-  Comma-separated: 1,234,567 cookies
-  Million format: 72.197 million cookies
-  Billion format: 13.564 billion cookies
-  Trillion format: 6.432 trillion cookies

##  Related

Improves user experience for players with high cookie counts.