### PR TITLE
fix(ci): update git-cliff-action to v4

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Generate changelog
-        uses: orhun/git-cliff-action@v3
+        uses: orhun/git-cliff-action@v4
         with:
           config: cliff.toml
           args: --verbose --latest --strip header


### PR DESCRIPTION
##  Problem

The changelog workflow is failing because orhun/git-cliff-action@v3 uses Debian Buster as base image, which reached End of Life and its repositories are no longer available (404 errors).

##  Solution

Update to orhun/git-cliff-action@v4 which uses a newer base image with supported repositories.

##  Changes

-  Update orhun/git-cliff-action from v3 to v4
-  Fixes Docker build failures in changelog workflow

##  Testing

This should resolve the following error:
`
E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
ERROR: failed to build: failed to solve: process /bin/sh -c apt-get update... did not complete successfully: exit code: 100
`

##  Related

- Fixes changelog generation workflow
- Part of CI/CD maintenance