### PR TITLE
refactor: standardize pr size labels nomenclature

### DIFF
--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -181,7 +181,7 @@ Automatically posts a beautiful statistics comment with:
 - 📈 Changes overview table (additions, deletions, net change)
 - 📁 Files changed/added/modified/deleted
 - 📝 Commit count
-- 📦 PR size indicator (🟢 Small / 🟡 Medium / 🟠 Large / 🔴 Very Large)
+- 📦 PR size indicator (🟢 XS/S / 🟡 M / 🟠 L / 🔴 XL)
 - 📄 Top 5 file types
 - 💡 Auto-updates on each push (no spam)
 

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -156,21 +156,24 @@ jobs:
               .map(([ext, count]) => `\`${ext}\` **${count}**`)
               .join(' • ');
 
-            // Calculate PR size
+            // Calculate PR size (matching size/* labels)
             const prSize = additions + deletions;
             let sizeEmoji, sizeLabel;
-            if (prSize < 100) {
+            if (prSize < 10) {
               sizeEmoji = '🟢';
-              sizeLabel = 'Small';
+              sizeLabel = 'XS';
+            } else if (prSize < 100) {
+              sizeEmoji = '🟢';
+              sizeLabel = 'S';
             } else if (prSize < 500) {
               sizeEmoji = '🟡';
-              sizeLabel = 'Medium';
+              sizeLabel = 'M';
             } else if (prSize < 1000) {
               sizeEmoji = '🟠';
-              sizeLabel = 'Large';
+              sizeLabel = 'L';
             } else {
               sizeEmoji = '🔴';
-              sizeLabel = 'Very Large';
+              sizeLabel = 'XL';
             }
 
             // Check if comment already exists


### PR DESCRIPTION
##  Summary

This PR standardizes the nomenclature used for PR size indicators to match the size/* labels used throughout the project.

##  Changes

### Size Label Standardization
-  Changed from descriptive names to abbreviated labels
-  Added XS category for very small PRs (< 10 lines)
-  Updated PR statistics comment to use consistent naming

### Before vs After

**Before:**
-  Small (< 100 lines)
-  Medium (100-500 lines)
-  Large (500-1000 lines)
-  Very Large (> 1000 lines)

**After:**
-  XS (< 10 lines)
-  S (10-100 lines)
-  M (100-500 lines)
-  L (500-1000 lines)
-  XL (> 1000 lines)

### Files Modified
- .github/workflows/pr-labeler.yml - Updated size calculation logic
- .github/WORKFLOWS.md - Updated documentation

##  Benefits

- **Consistency**: Matches size/xs, size/s, size/m, size/l, size/xl label names
- **Clarity**: Shorter, more recognizable size indicators
- **Granularity**: Added XS category for very small changes

##  Related

Part of workflow standardization and consistency improvements.