### PR TITLE
fix: add missing type variable and fix here-string indentation in release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,7 @@ jobs:
         id: release_notes
         shell: pwsh
         run: |
+          $type = "${{ steps.release_type.outputs.type }}"
           $sha = "${{ needs.build.outputs.checksum }}"
 
           $badge = switch ($type) {
@@ -135,12 +136,7 @@ jobs:
 
           $warning = ""
           if ("${{ steps.release_type.outputs.prerelease }}" -eq "true") {
-            $warning = @"
-
-            > ⚠️ **Pre-release Version**
-            > This is a pre-release version and may contain bugs or incomplete features.
-            > Use at your own risk. For stable releases, use the latest non-pre-release version.
-            "@
+            $warning = "> ⚠️ **Pre-release Version**`n> This is a pre-release version and may contain bugs or incomplete features.`n> Use at your own risk. For stable releases, use the latest non-pre-release version.`n"
           }
 
           $body = @"


### PR DESCRIPTION
Fixes PowerShell parser error in release notes generation step.

Changes:
- Add missing type variable from release_type outputs
- Replace multi-line here-string with inline string to avoid YAML parsing issues
- Fixes parser error: Missing closing curly brace in statement block

This resolves the error that was preventing release notes from being generated correctly.